### PR TITLE
修复nginx反代proxy_pass项设置错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ server {
 
     # 后端API代理配置
     location /api/ {
-        proxy_pass http://localhost:8787/;  # Docker后端服务地址
+        proxy_pass http://localhost:8787;  # Docker后端服务地址
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -496,7 +496,7 @@ server {
 
     # Backend API proxy configuration
     location /api/ {
-        proxy_pass http://localhost:8787/;  # Docker backend service address
+        proxy_pass http://localhost:8787;  # Docker backend service address
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
 


### PR DESCRIPTION
部署环境：docker-compose
问题：前端登录管理员账密后出现  未找到请求的资源错误 [#6](https://github.com/ling-drag0n/CloudPaste/issues/6)

去除nginx反代url末尾 **/** 后解决