### PR TITLE
fix: typo in bug_report issue template (“Cloudfare” → “Cloudflare”)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
       description: 采用的部署方式？
       options:
         - Docker
-        - Cloudfare worker
+        - Cloudflare worker
 
     validations:
       required: true


### PR DESCRIPTION
Fix typo in .github/ISSUE_TEMPLATE/bug_report.yml:

- Changed option label from “Cloudfare worker” to “Cloudflare worker” under 部署方式 dropdown.

No other code or documentation changes.