### PR TITLE
fix(authz): close proxy authorization bypasses

### DIFF
--- a/Api-doc.md
+++ b/Api-doc.md
@@ -1720,7 +1720,9 @@ X-Custom-Auth-Key: <api_key>
 
 - `POST /api/proxy/link`
   - 描述：统一存储链接解析接口
-  - 授权：支持管理员令牌、API 密钥或匿名访问
+  - 授权：
+    - `type = "fs"`：必须使用管理员令牌或 API 密钥；API 密钥需要 `MOUNT_VIEW`，且路径必须位于其 `basic_path` 和存储 ACL 范围内
+    - `type = "share"`：公开分享可匿名访问；密码分享必须在请求体提供正确的 `password`
   - 请求体：
     ```json
     {
@@ -1732,7 +1734,8 @@ X-Custom-Auth-Key: <api_key>
     ```json
     {
       "type": "share",
-      "slug": "file-slug"
+      "slug": "file-slug",
+      "password": "share-password"
     }
     ```
   - 响应：
@@ -1758,13 +1761,14 @@ X-Custom-Auth-Key: <api_key>
 - `GET /api/p/*`
   - 描述：文件系统代理访问路由（web_proxy 功能）
   - 路径格式：`/api/p/mount/path/file.ext`
-  - 授权：根据挂载点配置决定是否需要签名验证
+  - 授权：仅允许显式启用 `web_proxy` 的挂载；是否需要签名由全局/挂载签名配置决定
   - 查询参数：
     - `download` - 是否强制下载（可选，默认 false）
     - `sign` - 签名参数（当挂载点启用签名时必填）
   - 响应：文件内容流
   - 说明：
     - 专门用于 web_proxy 功能的文件代理访问
+    - 未启用 `web_proxy` 的挂载返回 403，不会通过该入口暴露
     - 支持 Range 请求，实现断点续传和视频流播放
     - 当挂载点配置 `enable_sign = true` 时，需要提供有效签名
     - 签名验证失败返回 401 Unauthorized

--- a/Cloudpaste-Proxy.js
+++ b/Cloudpaste-Proxy.js
@@ -363,6 +363,7 @@ export async function handleProxyRequest(request, env) {
 
     const controlUrl = new URL(ORIGIN);
     controlUrl.pathname = "/api/proxy/link";
+    const sharePassword = url.searchParams.get("password");
 
     const linkResp = await fetch(controlUrl.toString(), {
       method: "POST",
@@ -370,7 +371,7 @@ export async function handleProxyRequest(request, env) {
         "content-type": "application/json;charset=UTF-8",
         Authorization: TOKEN,
       },
-      body: JSON.stringify({ type: "share", slug }),
+      body: JSON.stringify({ type: "share", slug, ...(sharePassword ? { password: sharePassword } : {}) }),
     });
 
     // 分享视图同样增加详细调试日志，方便排查 502

--- a/backend/src/routes/fsProxyRoutes.js
+++ b/backend/src/routes/fsProxyRoutes.js
@@ -7,7 +7,7 @@
 
 import { Hono } from "hono";
 import crypto from "crypto";
-import { AppError, AuthenticationError, DriverError } from "../http/errors.js";
+import { AppError, AuthenticationError, AuthorizationError, DriverError } from "../http/errors.js";
 import { ApiStatus } from "../constants/index.js";
 import { MountManager } from "../storage/managers/MountManager.js";
 import { findMountPointByPathForProxy } from "../storage/fs/utils/MountResolver.js";
@@ -17,6 +17,7 @@ import { getEncryptionSecret } from "../utils/environmentUtils.js";
 import { getQueryBool } from "../utils/common.js";
 import { CAPABILITIES } from "../storage/interfaces/capabilities/index.js";
 import { StorageStreaming, STREAMING_CHANNELS } from "../storage/streaming/index.js";
+import { isWebProxyEnabled } from "../security/helpers/proxyAccess.js";
 
 // 签名代理路径不会走 RBAC，因此这里用结构化日志补充最少可观测性。
 const emitProxyAudit = (c, details) => {
@@ -244,6 +245,21 @@ fsProxyRoutes.get(`${PROXY_CONFIG.ROUTE_PREFIX}/*`, async (c) => {
       const status = mountResult.error.status;
       const code = status === 401 ? "UNAUTHORIZED" : status === 403 ? "FORBIDDEN" : status === 404 ? "NOT_FOUND" : "PROXY_ERROR";
       throw new AppError(mountResult.error.message, { status, code, expose: true });
+    }
+
+    // /api/p is the public entry point for mounts explicitly configured for
+    // web proxying. Without this check, any active mount could be streamed by
+    // using the special proxy user type below, even when web_proxy is off.
+    if (!isWebProxyEnabled(mountResult.mount)) {
+      emitProxyAudit(c, {
+        path,
+        decision: "deny",
+        reason: "web_proxy_disabled",
+        signatureRequired: false,
+        signatureProvided: Boolean(c.req.query(PROXY_CONFIG.SIGN_PARAM)),
+        mountId: mountResult.mount?.id ?? null,
+      });
+      throw new AuthorizationError("该挂载未启用代理访问");
     }
 
     // 挂载点验证成功，mountResult包含mount和subPath信息

--- a/backend/src/routes/fsRoutes.js
+++ b/backend/src/routes/fsRoutes.js
@@ -317,7 +317,8 @@ const getStorageConfigByUserType = async (db, configId, userIdOrInfo, userType, 
           allowed = allowedConfigIds.includes(configId);
         }
       } catch (error) {
-        console.warn("加载存储 ACL 失败，将回退到仅基于 is_public 的访问控制：", error);
+        console.error("加载存储 ACL 失败，拒绝扩大存储访问范围：", error);
+        throw new AuthorizationError("无法验证存储访问权限");
       }
     }
 

--- a/backend/src/routes/proxyLinkRoutes.js
+++ b/backend/src/routes/proxyLinkRoutes.js
@@ -10,10 +10,12 @@
 import { Hono } from "hono";
 import { ApiStatus, UserType } from "../constants/index.js";
 import { ValidationError, NotFoundError, AuthorizationError } from "../http/errors.js";
+import { usePolicy } from "../security/policies/policies.js";
 import { LinkService } from "../storage/link/LinkService.js";
 import { FileService } from "../services/fileService.js";
 import { getEncryptionSecret } from "../utils/environmentUtils.js";
 import { getPrincipal } from "../security/middleware/securityContext.js";
+import { isSharePasswordAccepted } from "../security/helpers/proxyAccess.js";
 
 const proxyLinkRoutes = new Hono();
 
@@ -35,6 +37,7 @@ async function parseLinkBody(c) {
   const type = body.type || "fs";
   const path = body.path || null;
   const slug = body.slug || null;
+  const password = typeof body.password === "string" ? body.password : null;
 
   if (!["fs", "share"].includes(type)) {
     throw new ValidationError("Invalid type, expected fs|share");
@@ -47,8 +50,32 @@ async function parseLinkBody(c) {
     throw new ValidationError("Missing slug for share type");
   }
 
-  return { type, path, slug };
+  return { type, path, slug, password };
 }
+
+const parseProxyLinkBody = async (c, next) => {
+  const body = await parseLinkBody(c);
+  c.set("proxyLinkBody", body);
+  await next();
+};
+
+const requireProxyFsRead = usePolicy("fs.read", {
+  pathResolver: (c) => c.get("proxyLinkBody")?.path,
+});
+
+const authorizeProxyLink = async (c, next) => {
+  const body = c.get("proxyLinkBody");
+
+  // FS upstream resolution returns direct/presigned storage access and must
+  // use the same authentication, permission and path checks as FS reads.
+  if (body?.type === "fs") {
+    return requireProxyFsRead(c, next);
+  }
+
+  // Share links remain usable by anonymous visitors, but password-protected
+  // shares are checked below before an upstream URL is returned.
+  return next();
+};
 
 /**
  * 统一响应格式
@@ -85,17 +112,18 @@ function buildLinkResponse({ url, header }) {
   };
 }
 
-proxyLinkRoutes.post("/api/proxy/link", async (c) => {
+proxyLinkRoutes.post("/api/proxy/link", parseProxyLinkBody, authorizeProxyLink, async (c) => {
   const db = c.env.DB;
   const encryptionSecret = getEncryptionSecret(c);
   const repositoryFactory = c.get("repos");
 
-  const { type, path, slug } = await parseLinkBody(c);
+  const { type, path, slug, password } = c.get("proxyLinkBody");
 
   const linkService = new LinkService(db, encryptionSecret, repositoryFactory);
   const fileService = new FileService(db, encryptionSecret, repositoryFactory);
 
-  // 使用 principal，支持 ADMIN / API_KEY / 匿名三种身份
+  // 使用 principal，支持 ADMIN / API_KEY / 匿名三种身份。
+  // FS 分支已由 requireProxyFsRead 强制认证；share 分支允许公开分享匿名解析。
   const principal = getPrincipal(c);
   let userType;
   let userIdOrInfo;
@@ -138,6 +166,10 @@ proxyLinkRoutes.post("/api/proxy/link", async (c) => {
 
     case "share": {
       const file = await fileService.getFileBySlug(slug);
+      if (!(await isSharePasswordAccepted(file, password))) {
+        throw new AuthorizationError("需要正确的文件密码");
+      }
+
       const access = fileService.isFileAccessible(file);
       if (!access.accessible) {
         if (access.reason === "expired") {
@@ -152,6 +184,7 @@ proxyLinkRoutes.post("/api/proxy/link", async (c) => {
         { type: userType, id: userType === UserType.ADMIN ? userIdOrInfo : userIdOrInfo?.id ?? null },
         {
           request: c.req.raw,
+          password,
         },
       );
       if (!storageLink || !storageLink.url) {

--- a/backend/src/routes/storageConfigRoutes.js
+++ b/backend/src/routes/storageConfigRoutes.js
@@ -19,7 +19,7 @@ import { getEncryptionSecret } from "../utils/environmentUtils.js";
 import { usePolicy } from "../security/policies/policies.js";
 import { resolvePrincipal } from "../security/helpers/principal.js";
 import { useRepositories } from "../utils/repositories.js";
-import { NotFoundError } from "../http/errors.js";
+import { NotFoundError, AuthorizationError } from "../http/errors.js";
 
 const storageConfigRoutes = new Hono();
 const requireRead = usePolicy("storage.config.read");
@@ -64,7 +64,8 @@ storageConfigRoutes.get("/api/storage", requireRead, async (c) => {
         filteredConfigs = configs.filter((cfg) => allowedSet.has(cfg.id));
       }
     } catch (error) {
-      console.warn("加载存储 ACL 失败，将回退到仅基于 is_public 的存储配置列表：", error);
+      console.error("加载存储 ACL 失败，拒绝扩大存储配置列表范围：", error);
+      throw new AuthorizationError("无法验证存储访问权限");
     }
   }
 
@@ -112,7 +113,8 @@ storageConfigRoutes.get("/api/storage/:id", requireRead, async (c) => {
         if (error instanceof NotFoundError) {
           throw error;
         }
-        console.warn("加载存储 ACL 失败，将回退到仅基于 is_public 的访问控制：", error);
+        console.error("加载存储 ACL 失败，拒绝扩大存储访问范围：", error);
+        throw new AuthorizationError("无法验证存储访问权限");
       }
     }
 

--- a/backend/src/security/helpers/proxyAccess.js
+++ b/backend/src/security/helpers/proxyAccess.js
@@ -1,0 +1,15 @@
+import { verifyPassword } from "../../utils/crypto.js";
+
+export const isWebProxyEnabled = (mount) => mount?.web_proxy === 1 || mount?.web_proxy === true;
+
+export const isMountAccessible = (mount, accessibleMounts) => {
+  const mountId = mount?.id;
+  return Boolean(mountId) && Array.isArray(accessibleMounts) && accessibleMounts.some((candidate) => candidate?.id === mountId);
+};
+
+export const isSharePasswordAccepted = async (file, password) => {
+  if (!file?.password) {
+    return true;
+  }
+  return Boolean(password) && verifyPassword(password, file.password);
+};

--- a/backend/src/services/apiKeyService.js
+++ b/backend/src/services/apiKeyService.js
@@ -2,7 +2,7 @@ import { generateRandomString } from "../utils/common.js";
 import { ApiStatus, DbTables } from "../constants/index.js";
 import { ensureRepositoryFactory } from "../utils/repositories.js";
 import { Permission, PermissionChecker } from "../constants/permissions.js";
-import { ValidationError, ConflictError, NotFoundError } from "../http/errors.js";
+import { ValidationError, ConflictError, NotFoundError, AuthorizationError } from "../http/errors.js";
 
 const resolveRepositoryFactory = ensureRepositoryFactory;
 
@@ -370,7 +370,8 @@ export async function getAccessibleMountsByBasicPath(db, basicPath, subjectType,
         allowedConfigIdsSet = new Set(allowedConfigIds);
       }
     } catch (error) {
-      console.warn("加载存储 ACL 失败，将回退到仅基于 is_public + basicPath 的过滤逻辑：", error);
+      console.error("加载存储 ACL 失败，拒绝扩大存储访问范围：", error);
+      throw new AuthorizationError("无法验证存储访问权限");
     }
   }
 

--- a/backend/src/services/fileShareService.js
+++ b/backend/src/services/fileShareService.js
@@ -1,5 +1,5 @@
 import { ApiStatus, UserType } from "../constants/index.js";
-import { ValidationError, NotFoundError, DriverError } from "../http/errors.js";
+import { ValidationError, NotFoundError, DriverError, AuthorizationError } from "../http/errors.js";
 import { ShareRecordService } from "./share/ShareRecordService.js";
 import { StorageQuotaGuard } from "../storage/usage/StorageQuotaGuard.js";
 
@@ -127,7 +127,8 @@ export class FileShareService {
           allowedConfigIdsSet = new Set(allowedIds);
         }
       } catch (error) {
-        console.warn("加载存储 ACL 失败，将回退到仅基于 is_public 的存储配置选择：", error);
+        console.error("加载存储 ACL 失败，拒绝扩大存储配置选择范围：", error);
+        throw new AuthorizationError("无法验证存储访问权限");
       }
     }
 

--- a/backend/src/storage/link/LinkService.js
+++ b/backend/src/storage/link/LinkService.js
@@ -12,6 +12,9 @@ import { findMountPointByPathForProxy } from "../fs/utils/MountResolver.js";
 import { ProxySignatureService } from "../../services/ProxySignatureService.js";
 import { WORKER_ENTRY, buildSignedProxyUrl, buildSignedWorkerUrl } from "../../constants/proxy.js";
 import { UserType } from "../../constants/index.js";
+import { AuthorizationError } from "../../http/errors.js";
+import { getAccessibleMountsForUser } from "../../security/helpers/access.js";
+import { isMountAccessible } from "../../security/helpers/proxyAccess.js";
 
 /**
  * 将文件名转为 URL path segment 安全的形式（用于 /api/s/:slug/:filename）。
@@ -32,13 +35,21 @@ function toUrlSafeFilename(filename) {
  * - 下载语义：追加 ?down=true
  * @param {string} slug
  * @param {string} filename
- * @param {{ download?: boolean }} [options]
+ * @param {{ download?: boolean, password?: string }} [options]
  * @returns {string}
  */
 function buildShareProxyPath(slug, filename, options = {}) {
   const safeName = toUrlSafeFilename(filename);
   const base = `/api/s/${encodeURIComponent(String(slug || ""))}/${encodeURIComponent(safeName)}`;
-  return options.download ? `${base}?down=true` : base;
+  const params = new URLSearchParams();
+  if (options.download) {
+    params.set("down", "true");
+  }
+  if (typeof options.password === "string" && options.password.length > 0) {
+    params.set("password", options.password);
+  }
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
 }
 
 /**
@@ -104,7 +115,7 @@ export class LinkService {
   /**
    * @param {Object} file
    * @param {{ type?: string, id?: string } | null} userInfo
-   * @param {{ mode?: "client" | "proxy", request?: Request }} [options]
+   * @param {{ mode?: "client" | "proxy", request?: Request, password?: string }} [options]
    * @returns {Promise<import('./LinkTypes.js').StorageLink>}
    */
   async getLinkForShare(file, userInfo = null, options = {}) {
@@ -120,7 +131,10 @@ export class LinkService {
     if (!file || !file.storage_config_id || !file.storage_path || !file.storage_type || !slug) {
       if (mode === "proxy") {
         // 兜底：直接返回 /api/s 下载路径，交由上层处理
-        const shareDownloadPath = `/api/s/${slug || ""}?down=true`;
+        const shareDownloadPath = buildShareProxyPath(slug || "", "file", {
+          download: true,
+          password: options.password,
+        });
         let finalUrl = shareDownloadPath;
         if (request) {
           try {
@@ -215,7 +229,10 @@ export class LinkService {
 
     // 1) use_proxy = 1：统一走本地 share 内容路由（下载语义）
     if (useProxyFlag) {
-      const shareDownloadPath = buildShareProxyPath(slug, file?.filename || "file", { download: true });
+      const shareDownloadPath = buildShareProxyPath(slug, file?.filename || "file", {
+        download: true,
+        password: options.password,
+      });
       let finalUrl = shareDownloadPath;
       if (request) {
         try {
@@ -264,7 +281,10 @@ export class LinkService {
       return createDirectLink(downloadDirectUrl);
     }
 
-    const shareDownloadPath = buildShareProxyPath(slug, file?.filename || "file", { download: true });
+    const shareDownloadPath = buildShareProxyPath(slug, file?.filename || "file", {
+      download: true,
+      password: options.password,
+    });
     let finalUrl = shareDownloadPath;
     if (request) {
       try {
@@ -342,6 +362,21 @@ export class LinkService {
       }
     } catch (e) {
       console.warn("解析挂载或存储配置失败，将退回 FS 默认链接策略：", e?.message || e);
+    }
+
+    // The upstream-http branch below can return a presigned/direct URL without
+    // going through FileSystem/MountManager. Re-run the API-key mount ACL here
+    // so this optimization cannot bypass storage visibility or ACL filtering.
+    if (mount && userType === UserType.API_KEY) {
+      const accessibleMounts = await getAccessibleMountsForUser(
+        this.db,
+        userIdOrInfo,
+        userType,
+        this.repositoryFactory,
+      );
+      if (!isMountAccessible(mount, accessibleMounts)) {
+        throw new AuthorizationError(`API密钥用户无权限访问挂载点: ${mount.name || mount.id}`);
+      }
     }
 
     // 仅在挂载未开启 web_proxy 时才允许 url_proxy 生效：

--- a/backend/test/proxy-authz.test.js
+++ b/backend/test/proxy-authz.test.js
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Hono } from "hono";
+
+import { Permission } from "../src/constants/permissions.js";
+import { hashPassword } from "../src/utils/crypto.js";
+import { isMountAccessible, isWebProxyEnabled, isSharePasswordAccepted } from "../src/security/helpers/proxyAccess.js";
+import { usePolicy } from "../src/security/policies/policies.js";
+import { getAccessibleMountsByBasicPath } from "../src/services/apiKeyService.js";
+
+const requireProxyFsRead = usePolicy("fs.read", {
+  pathResolver: (c) => c.get("proxyLinkBody")?.path,
+});
+
+const requestFsLink = async ({ principal }) => {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("principal", principal);
+    c.set("authService", {
+      checkBasicPathPermission(base, target) {
+        const normalizedBase = base === "/" ? "/" : String(base).replace(/\/+$/, "");
+        const normalizedTarget = String(target || "/").replace(/\/+$/, "") || "/";
+        return normalizedBase === "/" || normalizedTarget === normalizedBase || normalizedTarget.startsWith(`${normalizedBase}/`);
+      },
+    });
+    await next();
+  });
+  app.post(
+    "/api/proxy/link",
+    async (c, next) => {
+      c.set("proxyLinkBody", await c.req.json());
+      await next();
+    },
+    requireProxyFsRead,
+    (c) => c.json({ ok: true }),
+  );
+  app.onError((error, c) => c.json({ code: error.code }, error.status || 500));
+
+  return app.request("http://localhost/api/proxy/link", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ type: "fs", path: "/private/file.txt" }),
+  });
+};
+
+test("anonymous callers cannot resolve FS upstream links", async () => {
+  const response = await requestFsLink({
+    principal: { type: "anonymous", id: null, authorities: 0, attributes: {}, isAdmin: false },
+  });
+
+  assert.equal(response.status, 401);
+});
+
+test("API keys without MOUNT_VIEW cannot resolve FS upstream links", async () => {
+  const response = await requestFsLink({
+    principal: {
+      type: "apiKey",
+      id: "key-1",
+      authorities: 0,
+      attributes: { basicPath: "/private" },
+      isAdmin: false,
+    },
+  });
+
+  assert.equal(response.status, 403);
+});
+
+test("API keys cannot resolve FS links outside their basic path", async () => {
+  const response = await requestFsLink({
+    principal: {
+      type: "apiKey",
+      id: "key-1",
+      authorities: Permission.MOUNT_VIEW,
+      attributes: { basicPath: "/allowed" },
+      isAdmin: false,
+    },
+  });
+
+  assert.equal(response.status, 403);
+});
+
+test("local proxy access requires an explicitly enabled web_proxy mount", () => {
+  assert.equal(isWebProxyEnabled({ web_proxy: true }), true);
+  assert.equal(isWebProxyEnabled({ web_proxy: 1 }), true);
+  assert.equal(isWebProxyEnabled({ web_proxy: false }), false);
+  assert.equal(isWebProxyEnabled({ web_proxy: 0 }), false);
+  assert.equal(isWebProxyEnabled({}), false);
+});
+
+test("upstream link optimization honors the resolved mount ACL", () => {
+  const privateMount = { id: "private-mount" };
+  assert.equal(isMountAccessible(privateMount, [{ id: "public-mount" }]), false);
+  assert.equal(isMountAccessible(privateMount, [{ id: "private-mount" }]), true);
+  assert.equal(isMountAccessible(privateMount, null), false);
+});
+
+test("password-protected shares require the correct password", async () => {
+  const passwordHash = await hashPassword("correct horse battery staple");
+  const file = { password: passwordHash };
+
+  assert.equal(await isSharePasswordAccepted(file, null), false);
+  assert.equal(await isSharePasswordAccepted(file, "wrong"), false);
+  assert.equal(await isSharePasswordAccepted(file, "correct horse battery staple"), true);
+  assert.equal(await isSharePasswordAccepted({ password: null }, null), true);
+});
+
+test("ACL lookup failures fail closed instead of expanding mount access", async () => {
+  const repositoryFactory = {
+    getMountRepository: () => ({
+      findMany: async () => [{ id: "mount-1", mount_path: "/public", storage_config_id: "cfg-1" }],
+    }),
+    getStorageConfigRepository: () => ({
+      findById: async () => ({ id: "cfg-1", is_public: 1 }),
+    }),
+    getPrincipalStorageAclRepository: () => ({
+      findConfigIdsBySubject: async () => {
+        throw new Error("acl unavailable");
+      },
+    }),
+  };
+
+  await assert.rejects(
+    getAccessibleMountsByBasicPath({}, "/", "API_KEY", "key-1", repositoryFactory),
+    { code: "FORBIDDEN", status: 403 },
+  );
+});


### PR DESCRIPTION
## Summary

- restrict `/api/p/*` to mounts with `web_proxy` explicitly enabled
- require authentication, `MOUNT_VIEW`, `basicPath`, and storage ACL checks for FS proxy-link resolution, including upstream HTTP optimizations
- require and propagate passwords for protected share proxy links
- fail closed when storage ACL lookups fail instead of falling back to broader public access
- document the updated authorization contract

## Security impact

This closes paths that could return proxied content or upstream storage URLs without applying the same authorization constraints as normal FS and share reads.

## Tests

- `npm test -- --test-reporter=spec` (7 passed)
- `npx tsc --noEmit`
- `node --check` on modified JavaScript files
- `git diff --check`